### PR TITLE
feature/next aligned with latest r2-xxx-js packages (develop branches)

### DIFF
--- a/nodeExternals.js
+++ b/nodeExternals.js
@@ -124,7 +124,10 @@ module.exports = function nodeExternals(options) {
         const isWebPack = request.indexOf("webpack") >= 0 ||
             isRelative && context.indexOf("/node_modules/webpack") >= 0;
 
+        const isCSSLoader = request.indexOf("css-loader") >= 0 || request.indexOf("css-hot-loader") >= 0;
+
         const isCSS = request.endsWith(".css");
+        const isSVG = request.endsWith(".svg");
 
         const token = isRelative ? context + request : request;
         const isAlready = alreadyProcessed.indexOf(token) >= 0;
@@ -133,12 +136,12 @@ module.exports = function nodeExternals(options) {
         }
 
         const isR2Alias = /^@r2-.+-js/.test(request); // EXTERNAL
-        if (isR2Alias || isRelativeInNodeModules || isWebPack || isCSS) {
+        if (isR2Alias || isRelativeInNodeModules || isWebPack || isSVG || isCSS || isCSSLoader) {
             forceDebug = true;
         }
 
         // doesn't necessarily mean that WebPack will bundle, just that it won't externalize
-        const makeBundle = isWebPack || isCSS ||
+        const makeBundle = isWebPack || isSVG || isCSS || isCSSLoader ||
             (!isR2 && !isR2Alias && !isRelativeInNodeModules &&
             (isRDesk || isRelative || isElectron || isNode ||
                 request === "xxxpouchdb-core" // No need to force-bundle, as we now fixed di.ts to test for "default" property


### PR DESCRIPTION
DO NOT MERGE THIS PR. This is for information only (to track the code diff).

`feature/next` currently depends on the `r2-xxx-js` packages distributed in their corresponding `master` branches (these are frozen so that `feature/next` can evolve with stable `r2-xxx-js` dependencies):

`r2-utils-js`:
https://github.com/edrlab/r2-utils-js-dist/tree/master
Version / revision:
https://github.com/edrlab/r2-utils-js-dist/blob/master/dist/gitrev.json

`r2-opds-js`:
https://github.com/edrlab/r2-opds-js-dist/tree/master
Version / revision:
https://github.com/edrlab/r2-opds-js-dist/blob/master/dist/gitrev.json

`r2-lcp-js`:
https://github.com/edrlab/r2-lcp-js-dist/tree/master
Version / revision:
https://github.com/edrlab/r2-lcp-js-dist/blob/master/dist/gitrev.json

`r2-shared-js`:
https://github.com/edrlab/r2-shared-js-dist/tree/master
Version / revision
https://github.com/edrlab/r2-shared-js-dist/blob/master/dist/gitrev.json

`r2-streamer-js`:
https://github.com/edrlab/r2-streamer-js-dist/tree/master
Version / revision:
https://github.com/edrlab/r2-streamer-js-dist/blob/master/dist/gitrev.json

`r2-navigator-js`:
https://github.com/edrlab/r2-navigator-js-dist/tree/master
Version / revision:
https://github.com/edrlab/r2-navigator-js-dist/blob/master/dist/gitrev.json

`r2-testapp-js` (this one will eventually be removed):
https://github.com/edrlab/r2-testapp-js-dist/tree/master
Version / revision:
https://github.com/edrlab/r2-testapp-js-dist/blob/master/dist/gitrev.json

